### PR TITLE
feat: Fauce -> Add Docker CI

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,0 +1,23 @@
+name: Docker Build & Publish
+
+# Trigger on all push events, new semantic version tags, and all PRs
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+  pull_request:
+
+jobs:
+  docker-security-build:
+    permissions:
+      contents: write
+      packages: write
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@main # yamllint disable-line rule:line-length
+    with:
+      dockerfile: Dockerfile
+      packageName: faucet


### PR DESCRIPTION
## Overview

Hello team!

I've used our docker CI pipeline for creating the faucet's image.

Need to merge this one to have the image available in the registry.

You can check an execution here: [link](https://github.com/celestiaorg/cosmfaucet/actions/runs/4281939034/jobs/7455612607)

Thanks in advance!

## Checklist

- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
